### PR TITLE
prefer manga title of /hc.fyi/

### DIFF
--- a/gallery_dl/extractor/hentaicafe.py
+++ b/gallery_dl/extractor/hentaicafe.py
@@ -32,7 +32,7 @@ class HentaicafeChapterExtractor(foolslide.FoolslideChapterExtractor):
         manga, _, chapter_string = info.partition(" :: ")
 
         data = self._data(self.gallery_url.split("/")[5])
-        data["manga"] = manga
+        data.setdefault('manga', manga)  # set manga, which defaults to that from MangaExtractor
         data["chapter_string"] = chapter_string.rstrip(" :")
         return self.parse_chapter_url(self.gallery_url, data)
 
@@ -80,11 +80,14 @@ class HentaicafeMangaExtractor(foolslide.FoolslideMangaExtractor):
             chapters.reverse()
             return chapters
 
-        url   , pos = text.extract(page, '<link rel="canonical" href="', '"')
+        manga_title: str
+        manga_title, pos = text.extract(page, '<title>', '</title>')
+        url, pos = text.extract(page, '<link rel="canonical" href="', '"', pos)
         tags  , pos = text.extract(page, "<p>Tags: ", "</br>", pos)
         artist, pos = text.extract(page, "\nArtists: ", "</br>", pos)
         manga , pos = text.extract(page, "/manga/read/", "/", pos)
         data = {
+            'manga'   : manga_title.partition(' | ')[0],
             "manga_id": text.parse_int(url.rpartition("/")[2]),
             "tags"    : text.split_html(tags)[::2],
             "artist"  : text.split_html(artist),


### PR DESCRIPTION
when set the "manga" metadata, prefer it in the manga page (with /hc.fyi/ in URL), to that in the chapter page
reason: some mangas have different title in manga page and in chapter page

example:
https://hentai.cafe/hc.fyi/1349
this page has title which starts with "[Distance] Devil Sisters!"
while in its chapter page (https://hentai.cafe/manga/read/devil_sisters/en/0/1/page/1), the title starts with "Devil Sisters!"

solution:
for such situations, extract "manga" metadata in /hc.fyi/ page if possible, and reuse it in chapter page